### PR TITLE
Support M1 Macs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,10 @@ jobs:
           name: OS specific binaries
           path: dist
 
+      - name: Include M1 build
+        run: |
+          mv ./build/osx/tiktoken-node.darwin-arm64.node ./dist/osx/
+
   deploy:
     # prevents this action from running on forks or pull requests
     if: ${{ github.repository == 'ceifa/tiktoken-node' && github.event_name == 'push' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,10 +44,6 @@ jobs:
           name: OS specific binaries
           path: dist
 
-      - name: Include M1 build
-        run: |
-          mv ./build/osx/tiktoken-node.darwin-arm64.node ./dist/osx/
-
   deploy:
     # prevents this action from running on forks or pull requests
     if: ${{ github.repository == 'ceifa/tiktoken-node' && github.event_name == 'push' }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
 /dist
+!/dist/tiktoken-node.darwin-arm64.node
 node_modules
 Cargo.lock


### PR DESCRIPTION
Include pre-built binary for `tiktoken` on Apple Silicon based macOS.


Should fix #2 

Also opened up a [PR here](https://github.com/aarohmankad/tiktoken-node/pull/1) in case you want to use the PR started by @aarohmankad.