### PR TITLE
fix: add `exports.types` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "name": "tiktoken-node"
     },
     "exports": {
+        "types": "./index.d.ts",
         "import": "./index.mjs",
         "require": "./index.cjs"
     },


### PR DESCRIPTION
Without the `types` field, `"moduleResolution": "NodeNext"` does not work:

```
Could not find a declaration file for module 'tiktoken-node'. '/.../node_modules/tiktoken-node/index.mjs' implicitly has an 'any' type.
  There are types at '/.../node_modules/tiktoken-node/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'tiktoken-node' library may need to update its package.json or typings.ts(7016)
```