### PR TITLE
Cross-compile rust binaries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,12 +5,21 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  DEBUG: 'napi:*'
+  MACOSX_DEPLOYMENT_TARGET: '10.13'
+
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [windows-2022, ubuntu-20.04, macos-11]
+        target:
+          - x86_64-pc-windows-msvc
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
 
     steps:
       - uses: actions/checkout@v3
@@ -25,24 +34,39 @@ jobs:
         with:
           toolchain: stable
           override: true
+          target: ${{ matrix.target }}
+
+      - name: Install ziglang
+        uses: goto-bus-stop/setup-zig@v1
+        with:
+          version: 0.10.0
+
+      - run: cargo install cargo-xwin
+        if: matrix.target == 'x86_64-pc-windows-msvc'
 
       - name: Check formatting
         uses: actions-rs/cargo@v1
-        if: runner.os == 'linux'
         with:
           command: fmt
           args: --all -- --check
 
-      - name: Build
-        run: |
-          npm i
-          npm run build
+      - name: Node install
+        run: npm i
+
+      - name: Build Mac and Linux
+        if: matrix.target != 'x86_64-pc-windows-msvc'
+        run:  npm run build -- --zig --target ${{ matrix.target }}
+
+      - name: Build Windows
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        run:  npm run build -- --target ${{ matrix.target }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: OS specific binaries
           path: dist
+          if-no-files-found: error
 
   deploy:
     # prevents this action from running on forks or pull requests
@@ -58,7 +82,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: OS specific binaries
-          path: dist
+          path: dist/
 
       - name: Log files
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /target
 /dist
-!/dist/tiktoken-node.darwin-arm64.node
+.idea/
 node_modules
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiktoken-node"
-version = "0.0.1"
+version = "0.0.6"
 edition = "2021"
 
 [lib]
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 napi = "2"
 napi-derive = "2"
 # tokio = "1"
-tiktoken-rs = "0.3.2"
+tiktoken-rs = "0.4.0"
 # futures = "0.3.27"
 
 [build-dependencies]

--- a/index.cjs
+++ b/index.cjs
@@ -4,8 +4,12 @@ let nativeBinding = undefined
 
 if (platform === 'win32' && arch === 'x64') {
     nativeBinding = require('./dist/tiktoken-node.win32-x64-msvc.node')
-} else if (platform === 'linux' && arch === 'x64') {
-    nativeBinding = require('./dist/tiktoken-node.linux-x64-gnu.node')
+} else if (platform === 'linux') {
+    if (arch === 'x64') {
+        nativeBinding = require('./dist/tiktoken-node.linux-x64-gnu.node')
+    } else if (arch === 'arm64') {
+        nativeBinding = require('./dist/tiktoken-node.linux-arm64-gnu.node')
+    }
 } else if (platform === 'darwin') {
     if (arch === 'x64') {
         nativeBinding = require('./dist/tiktoken-node.darwin-x64.node')

--- a/index.mjs
+++ b/index.mjs
@@ -7,8 +7,12 @@ let nativeBinding = undefined
 
 if (platform === 'win32' && arch === 'x64') {
     nativeBinding = require('./dist/tiktoken-node.win32-x64-msvc.node')
-} else if (platform === 'linux' && arch === 'x64') {
-    nativeBinding = require('./dist/tiktoken-node.linux-x64-gnu.node')
+} else if (platform === 'linux') {
+    if (arch === 'x64') {
+        nativeBinding = require('./dist/tiktoken-node.linux-x64-gnu.node')
+    } else if (arch === 'arm64') {
+        nativeBinding = require('./dist/tiktoken-node.linux-arm64-gnu.node')
+    }
 } else if (platform === 'darwin') {
     if (arch === 'x64') {
         nativeBinding = require('./dist/tiktoken-node.darwin-x64.node')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "tiktoken-node",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "tiktoken-node",
-            "version": "0.0.5",
+            "version": "0.0.6",
             "license": "MIT",
             "devDependencies": {
                 "@napi-rs/cli": "2.15.1",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,19 @@
 {
     "name": "tiktoken-node",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "types": "index.d.ts",
     "main": "index.cjs",
     "napi": {
-        "name": "tiktoken-node"
+        "name": "tiktoken-node",
+        "triples": {
+            "additional": [
+                "x86_64-pc-windows-msvc",
+                "x86_64-unknown-linux-gnu",
+                "aarch64-unknown-linux-gnu",
+                "x86_64-apple-darwin",
+                "aarch64-apple-darwin"
+            ]
+        }
     },
     "exports": {
         "types": "./index.d.ts",


### PR DESCRIPTION
We need to compile binaries for multiple platforms. Previously we were doing this by running the build on multiple github runners. Unfortunately github doesn't provide all the platforms we need to build, namely arm64 platforms.

Follow the example from https://github.com/napi-rs/cross-build on how to cross-compile rust binaries using napi-rs to build binaries for windows, mac, and linux for x86 and arm architectures.

- Run only on ubuntu-latest, but specify the rust build target in the matrix and install the required toolchains.
- Need to install xwin for the windows target
- Install zig and use it for linking for macos and linux
- Update to use tiktoken-rs version 0.4.0 which fixes some bugs, but also makes the dependency on async-openai optional which reduces the binary size, but also removes a lot of other dependencies that were complicating the build. `tiktoken-node` doesn't seem to need any of these dependencies anyway.
- Update version number to 0.0.6